### PR TITLE
Discourage installing new software into the base environment

### DIFF
--- a/_episodes/01-getting-started-with-conda.md
+++ b/_episodes/01-getting-started-with-conda.md
@@ -210,14 +210,6 @@ $ conda update -y conda
 
 You can re-run this command at any time to update to the most recent version of Conda.
 
-> ## Avoid installing packages into your `base` Conda environment
->
-> It is a "best practice" to avoid installing additional packages into your `base` software 
-> environment. Additional packages needed for a new project should always be installed into a 
-> newly created Conda environment.  You will see how to create new environments and install 
-> packages in the next episode.
-{: .callout}
-
 > ## Verifying your Conda installation
 >
 > Confirm that you have installed Conda correctly on your machine. What is the version number?

--- a/_episodes/01-getting-started-with-conda.md
+++ b/_episodes/01-getting-started-with-conda.md
@@ -241,7 +241,7 @@ Once you restart your shell (or reload your `.bashrc` profile) you should see a 
 
 The `(base)` in front of the `$` prompt indicates that the currently active Conda environment is the default `base` environment.
 
-> ## Avoid installing software into your `base` Conda environment
+> ## Avoid installing packages into your `base` Conda environment
 >
 > It is a "best practice" to avoid installing additional packages into your `base` software 
 > environment. Additional packages needed for a new project should always be installed into a 

--- a/_episodes/01-getting-started-with-conda.md
+++ b/_episodes/01-getting-started-with-conda.md
@@ -233,6 +233,22 @@ $ . ~/.bashrc
 ~~~
 {: .language-bash}
 
+Once you restart your shell (or reload your `.bashrc` profile) you should see a slightly modified prompt.
+
+~~~
+(base) $
+~~~
+
+The `(base)` in front of the `$` prompt indicates that the currently active Conda environment is the default `base` environment.
+
+> ## Avoid installing software into your `base` Conda environment
+>
+> It is a "best practice" to avoid installing additional packages into your `base` software 
+> environment. Additional packages needed for a new project should always be installed into a 
+> newly created Conda environment.  You will see how to create new environments and install 
+> packages in the next episode.
+{: .callout}
+
 > ## Verifying your Conda installation
 >
 > Confirm that you have installed Conda correctly on your machine. What is the version number?

--- a/_episodes/02-working-with-environments.md
+++ b/_episodes/02-working-with-environments.md
@@ -35,6 +35,14 @@ project has NumPy 1.12 (perhaps because version 1.12 was the most current versio
 time the project finished). If you change one environment, your other environments are not 
 affected. You can easily activate or deactivate environments, which is how you switch between them.
 
+> ## Avoid installing packages into your `base` Conda environment
+>
+> Conda has a default environment called `base` that include a Python installation and some core 
+> system libraries and dependencies of Conda. It is a "best practice" to avoid installing 
+> additional packages into your `base` software environment. Additional packages needed for a new 
+> project should always be installed into a newly created Conda environment.
+{: .callout}
+
 ## Creating environments
 
 To create a new environment for Python development using `conda` you should use the `create` 


### PR DESCRIPTION
Generally a good idea to avoid installing packages into the default `base` environment and to always install additional packages into newly created environments. This PR adds a callout box to the effect.

> ## Avoid installing packages into your `base` Conda environment
>
> It is a "best practice" to avoid installing additional packages into your `base` software 
> environment. Additional packages needed for a new project should always be installed into a 
> newly created Conda environment.  You will see how to create new environments and install 
> packages in the next episode.
{: .callout}