### PR TITLE
Prefer source activate over conda activate

### DIFF
--- a/_episodes/01-getting-started-with-conda.md
+++ b/_episodes/01-getting-started-with-conda.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started with Conda"
 teaching: 15
-exercises: 10
+exercises: 5
 questions:
 - "Why should I use a package and environment management system as part of my research workflow?"
 - "What is Conda?"
@@ -192,14 +192,13 @@ $ which conda
 {: .language-bash}
 
 If Conda has already been installed on your machine, then you this command should return the 
-absolute path to the conda executable.
+absolute path to the conda executable. If Conda has not been installed on your machine, then 
+install the Python 3 version of [Miniconda](https://docs.conda.io/en/latest/miniconda.html) from 
+Anaconda for your OS. Miniconda is mini version of the 
+[Anaconda Python distribution](https://www.anaconda.com/distribution/) that includes only Conda 
+and its dependencies.
 
-If Conda has not been installed on your machine, then install the Python 3 version of 
-[Miniconda](https://docs.conda.io/en/latest/miniconda.html) from Anaconda for your OS. Miniconda 
-is mini version of the [Anaconda Python distribution](https://www.anaconda.com/distribution/) 
-that includes only Conda and its dependencies.
-
-### Make sure you have the most recent version
+## Make sure you have the most recent version
 
 Once Conda exists on your machine, then run the following command to make sure that you 
 have the most recent version and patches.
@@ -210,43 +209,6 @@ $ conda update -y conda
 {: .language-bash}
 
 You can re-run this command at any time to update to the most recent version of Conda.
-
-### Make sure that Conda is properly setup for your shell
-
-Conda 4.4 introduced new scripts that make activation behavior uniform across operating systems. 
-Where previously you once had `source activate envname` on unix, and just `activate envname` on 
-windows, Conda 4.4 allowed `conda activate envname`.  Setting up your shell to use this new 
-feature was tricky. Conda 4.6 added extensive initialization support so that more shells can use 
-the new `conda activate` command. For more information, read the output from `conda init –-help`. 
-
-~~~
-$ conda init
-~~~
-{: .language-bash}
-
-After running `conda init` you will need to close and restart your shell for changes to take 
-effect. Alternatively, you can reload your `.bashrc` profile (which was changed by running the 
-`conda init` command).  To reload your `.bashrc` profile, use the following command.
-
-~~~
-$ . ~/.bashrc
-~~~
-{: .language-bash}
-
-> ## Reversing `conda init` side-effects
->
-> Running the `conda init` command inserts some `bash` code into your `~/.bashrc` file. If you 
-> want to reverse or "undo" these changes, then you can re-run the `conda init` command and pass 
-> the `--reverse` option.
->
-> ~~~
-> (base) $ conda init --reverse
-> ~~~
-> {: .language-bash}
->
-> Again, in order for the reversal to take effect you will likely need to close and restart your 
-> shell session.
-{: .callout} 
 
 > ## Verifying your Conda installation
 >
@@ -319,14 +281,6 @@ $ . ~/.bashrc
 > > # All requested packages already installed.
 > > ~~~
 > > {: .language-bash}
-> >
-> > If your current version needed to be updated, then the output of the command should look 
-> > similar to the following.
-> > 
-> > ~~~
-> > $ conda update -n base conda
-> > ???
-> > ~~~
 > > 
 > > Once the update process is complete you can check the version number as follows.
 > > ~~~

--- a/_episodes/02-working-with-environments.md
+++ b/_episodes/02-working-with-environments.md
@@ -138,14 +138,19 @@ sometimes at all!). Activation of an environment does two things.
 2. Runs any activation scripts that the environment may contain.
 
 Step 2 is particularly important as activation scripts are how packages can set arbitrary 
-environment variables that may be necessary for their operation.
-
-To activate the `my-second-conda-env` environment by name use the `activate` command as follows.
+environment variables that may be necessary for their operation. On a Unix system you activate the 
+`my-second-conda-env` environment by name using the following command.
 
 ~~~
-$ conda activate my-second-conda-env
+$ source activate my-second-conda-env
 ~~~
 {: .language-bash}
+
+On Windows the command to activate an environment by name is slightly different.
+
+~~~
+$ activate my-second-conda-env
+~~~
 
 You can see that an environment has been activated because the shell prompt will now include the 
 name of the active environment.
@@ -154,16 +159,49 @@ name of the active environment.
 (my-second-conda-env) $
 ~~~
 
+> ## Initializing Conda properly setup for your shell
+> 
+> Conda 4.4 introduced new scripts that make activation behavior uniform across operating systems. 
+> Where previously you once had `source activate envname` on Unix, and just `activate envname` on 
+> Windows, Conda 4.4 allowed `conda activate envname`.  Setting up your shell to use this new 
+> feature was tricky. Conda 4.6 added extensive initialization support so that more shells can use 
+> the new `conda activate` command. For more information, read the output from `conda init –-help`. 
+> 
+> ~~~
+> $ conda init bash
+> ~~~
+> {: .language-bash}
+> 
+> After running `conda init` you will need to close and restart your shell for changes to take 
+> effect. Alternatively, you can reload your `.bashrc` profile (which was changed by running the 
+> `conda init` command).  To reload your `.bashrc` profile, use the following command.
+>
+> ~~~
+> $ . ~/.bashrc
+> ~~~
+>
+> If you want to reverse or "undo" the changes to your `.bashrc`, then you can re-run the 
+> `conda init` command and pass the `--reverse` option.
+>
+> ~~~
+> (base) $ conda init --reverse
+> ~~~
+> {: .language-bash}
+>
+> Again, in order for the reversal to take effect you will likely need to close and restart your 
+> shell session.
+{: .callout} 
+
 > ## Activate an existing environment by name
 >
 > Activate the "explicit-conda-env" environment created in the previous challenge by name.
 > 
 > > ## Solution
 > > 
-> > In order to activate an existing environment by name you use the `conda activate` command as follows.
+> > In order to activate an existing environment by name you use the `source activate` command as follows.
 > > 
 > > ~~~
-> > $ conda activate explicit-conda-env
+> > $ source activate explicit-conda-env
 > > ~~~
 > > {: .language-bash}
 > >
@@ -189,7 +227,7 @@ $
 
 > ## Returning to the `base` environment
 >
-> To simply return to the `base` Conda environment, it's better to call `conda activate` with no 
+> To simply return to the `base` Conda environment, it's better to call `source activate` with no 
 > environment specified, rather than to use `deactivate`. If you run `conda deactivate` from your 
 > `base` environment, you may lose the ability to run `conda` commands at all. **Don't worry if 
 > you encounter this undesirable state! Just start a new shell.**
@@ -239,7 +277,7 @@ Note that the name of the environment that is created using this command is `my-
 can it activate the environment as follows.
 
 ~~~
-$ conda activate my-local-env
+$ source activate my-local-env
 ~~~
 {: .language-bash}
 

--- a/_episodes/02-working-with-environments.md
+++ b/_episodes/02-working-with-environments.md
@@ -21,7 +21,7 @@ objectives:
 keypoints:
 - "A Conda environment is a directory that contains a specific collection of Conda packages that you have installed."
 - "You create (remove) a new environment using the `conda create` (`conda remove`) commands."
-- "You activate (deactivate) an environment using the `conda activate` (`conda deactivate`) commands."
+- "You activate (deactivate) an environment using the `source activate` (`conda deactivate`) commands."
 - "You should install each environment as a sub-directory inside its corresponding project directory"
 - "Use the `conda env list` command to list existing environments and their respective locations."
 - "Use the `conda list` command to list all of the packages installed in an environment."
@@ -306,7 +306,7 @@ environments in your `~/miniconda3/env/` folder, you’ll have to give each of t
 > 
 > ~~~ 
 > $ cd my-project/
-> $ conda activate ./env
+> $ source activate ./env
 > ~~~
 > {: .language-bash}
 {: .callout}
@@ -374,7 +374,7 @@ you do not. Now your command prompt will display the active environment’s gene
  
 ~~~
 $ cd project-directory
-$ conda activate ./env
+$ source activate ./env
 (env) project-directory $
 ~~~
 {: .language-bash}
@@ -389,10 +389,10 @@ For more on modifying your `.condarc` file, see [the docs][conda-docs].
 > > ## Solution
 > > 
 > > You can activate an existing environment by providing the path the the environment directory 
-> > instead of the environment name when using the `conda activate` command as follows.
+> > instead of the environment name when using the `source activate` command as follows.
 > > 
 > > ~~~
-> > $ conda activate ./env
+> > $ source activate ./env
 > > ~~~
 > > {: .language-bash}
 > >

--- a/_episodes/03-sharing-environments.md
+++ b/_episodes/03-sharing-environments.md
@@ -268,7 +268,7 @@ task.
 ~~~
 $ cd project-dir
 $ conda env create --prefix ./env --file environment.yml
-$ conda activate ./env
+$ source activate ./env
 ~~~
 {: .language-bash}
 

--- a/_episodes/04-using-packages-and-channels.md
+++ b/_episodes/04-using-packages-and-channels.md
@@ -236,7 +236,7 @@ how we would install the package into our environment using `pip`.
 
 ~~~
 $ conda install pip --prefix ./env
-$ conda activate ./env
+$ source activate ./env
 $ pip install $SOME_PACKAGE 
 ~~~
 {: .language-bash}

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,6 +1,26 @@
 ---
 title: "Instructor Notes"
 ---
-FIXME
+
+## Conda on HPC systems
+
+Many HPC systems make either Miniconda or Anaconda (or both!) available to users via 
+[Environment Modules](http://modules.sourceforge.net/). In this case a user will need to load the 
+relevant module instead of installing Conda.
+
+~~~
+$ module load miniconda
+~~~
+{: .language-bash}
+
+> ## Avoid running the `conda init` command
+> 
+> Using the `conda init` command is not advisable on HPC systems that use Environment Modules 
+> to make Miniconda or Anaconda available to users.  The reason is that running the `conda init` 
+> command makes changes to a user's `~/.bashrc` file. If the user subsequently forgets to reverse 
+> these changes using `conda init --reverse`, then `conda` will still be available even after 
+> unloading or purging the `miniconda` module.  This opens the distinct possibility of a user 
+> accidently leaving his/her shell environment in an unexpected state.
+{: .callout}    
 
 {% include links.md %}


### PR DESCRIPTION
This PR moves the section on "setting up Conda properly for your shell" to a callout box in episode 2 and switches to use the `source activate` command instead of `conda activate` command. Reason for this change is that on HPC systems that provide access to Conda via the module system, there is no way to make the conda activate command available to users without having the module system modify the user's `.bashrc` file at which point it becomes very easy for the user to leave their shell environment in an unexpected state.