### PR TITLE
few smaller changes in mostly wording, xgboost removed, '==' for pip in yml

### DIFF
--- a/_episodes/01-getting-started-with-conda.md
+++ b/_episodes/01-getting-started-with-conda.md
@@ -5,47 +5,109 @@ exercises: 5
 questions:
 - "What is Conda?"
 - "Why should I use a package and environment management system as part of my research workflow?"
-- "Why use Conda (+pip)?"
+- "Why use Conda ?"
 objectives:
 - "Understand why you should use a package and environment management system as part of your 
   (data) science workflow." 
-- "Explain the benefits of using Conda (+pip) as part of your (data) science workflow."
+- "Explain the benefits of using Conda as part of your (data) science workflow."
 keypoints:
 - "Conda is a platform agnostic, open source package and environment management system."
 - "Using a package and environment management tool facilitates portability and reproducibility 
   of (data) science workflows."
-- "Conda (+pip) solves both the package and environment management problems and targets multiple 
+- "Conda  solves both the package and environment management problems and targets multiple 
   programming languages. Other open source tools solve either one or the other, or target only 
   a particular programming language."
+- " Anaconda is not only for Python"
 ---
 
-## What is Conda?
+## Packages and Environments
 
-From the [official Conda documentation](https://conda.io/projects/conda/en/latest/index.html). 
-Conda is an open source package and environment management system that runs on Windows, Mac OS and 
-Linux.
+### Packages
 
-*   Conda can quickly install, run, and update packages and their dependencies.
-*   Conda can create, save, load, and switch between project specific software environments on 
-    your local computer. 
-*   Although Conda was created for Python programs, Conda can package and distribute software for 
-    any language such as R, Ruby, Lua, Scala, Java, JavaScript, C, C++, FORTRAN.
+When working with a programming language, such as Python, that can do almost _anything_, one has to wonder how this is possible. You download Python, it has about 25 MB, how can everthing be included in this small data package. The answer is - it is not. Python, as well as many other programming languages use external libraries or packages for being able to doing almost _anything_. You can see this already when you start programming. After learning some very basics, you often learn how to *import* something into your script or session.
 
-Conda as a *package manager* helps you find and install packages. If you need a package that 
-requires a different version of Python, you do not need to switch to a different environment 
-manager, because Conda is also an *environment manager*. With just a few commands, you can set up 
-a totally separate environment to run that different version of Python, while continuing to run 
-your usual version of Python in your normal environment. 
+> ## Modules, packages, libraries
+>
+> * Module: a collection of functions and variables, as in a script
+> * Package: a collection of modules with an __init__.py file (can be empty), as in a directory with scripts
+> * Library: a collection of packages with realted functionality
+>
+> Library/Package are often used interchangeably.
+{: .callout}
 
-> ## Conda vs. Miniconda vs. Anaconda
-> 
-> <p align="center">
->   <img alt="Conda vs. Miniconda vs. Anaconda" src="../fig/miniconda_vs_anaconda.png" width="500">
-> </p>
-> Users are often confused about the differences between Conda, Miniconda, and Anaconda. Conda is 
-> a tool for managing environments and installing packages. Miniconda combines Conda with Python 
-> and a small number of core packages; Anaconda includes Miniconda as well as a large number of 
-> the most widely used Python packages. 
+### Dependencies
+
+A bit further into your programming career you may notice/have noticed that many packages do not just do everything on their own. Instead, they _depend_ on other packages for their functionality. For example, the [Scipy package](https://www.scipy.org/about.html) is used for numerical routines. To not reinvent the wheel, the package makes use of other packages, such as numpy (numerical python) and matplotlib (plotting) and many more. So we say that numpy and matplotlib are *dependencies* of Scipy. 
+
+Many packages are being further developed all the time, generating different *versions* of packages. During development it may happen that a function call changes and/or functionalities are added or removed. If one package can depend on another, this may create issues. Therefore it is not only important to know that e.g. Scipy depends on numpy and matplotlib, but also that it depends on numpy version >= 1.6 and matplotlib version >= 1.1. Numpy version 1.5 in this case would not be sufficient.
+
+### Environments
+
+When starting with programming we may not use many packages yet and the installation may be straightforward. But for most people, there comes a time when one version of a package or also the programming language is not enough anymore. You may find an older tool that depends on an older version of your programming language (e.g. Pyhton 2.7), but many of your other tools depend on a newer version (e.g. Python 3.6). You could now start up another computer or virtual machine to run the other version of the programming language, but this is not very handy, since you may want to use the tools together in a workflow later on. Here, *environments* are one solution to the problem.
+Nowadays there are several environment management systems following a similar idea:
+Instead of having to use multiple computers or virtual machines to run different versions of the same package, you can install packages in isolated environments.
+
+### Environment management
+
+An environment management system solves a number of problems commonly encountered by (data) 
+scientists.
+
+*   An application you need for a research project requires different versions of your base 
+    programming language or different versions of various third-party packages from the versions 
+    that you are currently using.
+*   An application you developed as part of a previous research project that worked fine on your 
+    system six months ago now no longer works.
+*   Code that have written for a joint research project works on your machine but not on your 
+    collaborators' machines.
+*   An application that you are developing on your local machine doesn't provide the same results 
+    when run on your remote cluster.
+
+An environment management system enables you to set up a new, project specific software environment 
+containing specific Python versions as well as the versions of additional packages and 
+required dependencies that are all mutually compatible.
+
+*   Environment management systems help resolve dependency issues by allowing you to use different 
+    versions of a package for different projects.
+*   Make your projects self-contained and reproducible by capturing all package dependencies in a 
+    single requirements file.
+*   Allow you to install packages on a host on which you do not have admin privileges.
+
+> ## Environment management systems for Python
+> Conda is not the only way; Python for example has many more ways of working with environments:
+> * [virtualenv](https://virtualenv.pypa.io/en/latest/)
+> * [pipenv](https://pipenv.pypa.io/en/latest/)
+> * [venv](https://docs.python.org/3/library/venv.html)
+> * [pyenv](https://github.com/pyenv/pyenv)
+> * ...
+{: .callout}
+
+### Package management
+
+A good package management system greatly simplifies the process of installing software by... 
+
+1.  identifying and installing compatible versions of software and all required dependencies. 
+2.  handling the process of updating software as more recent versions become available.
+
+If you use some flavor of Linux, then you are probably familiar with the package manager for your 
+Linux distribution (i.e., `apt` on Ubuntu, `yum` on CentOS); if you are a Mac OSX user then you 
+might be familiar with the [Home Brew Project](https://brew.sh/) which brings a Linux-like package 
+management system to Mac OS; if you are a Windows OS user, then you may not be terribly familiar 
+with package managers as there isn't really a standard package manager for Windows (although there 
+is the [Chocolatey Project](https://chocolatey.org/)).  
+
+Operating system package management tools are great but these tools actually solve a more general 
+problem than you often face as a (data) scientist.  As a (data) scientist you typically use one or 
+two core scripting languages (i.e.,  Python, R, SQL). Each scripting language has multiple 
+versions that can potentially be installed and each scripting language will also have a large 
+number of third-party packages that will need to be installed. The exact version of your core 
+scripting language(s) and additional, third-party packages will also probably change from project 
+to project.
+
+> ## Package management systems for Python
+> Also here, Conda is not the only way; Python for example has many more ways of working with packages:
+> * [pip](https://pip.pypa.io/en/stable/)
+> * [Poetry](https://python-poetry.org/)
+> * ...
 {: .callout}
 
 ## Why should I use a package and environment management system?
@@ -87,54 +149,36 @@ What I hope you will have taken away from the discussion exercise is an apprecia
 that in order to install project-specific software environments you need to solve two complementary 
 challenges: environment management and package management.
 
-### Environment management
+## Conda
 
-An environment management system solves a number of problems commonly encountered by (data) 
-scientists.
+From the [official Conda documentation](https://conda.io/projects/conda/en/latest/index.html). 
+Conda is an open source package and environment management system that runs on Windows, Mac OS and 
+Linux.
 
-*   An application you need for a research project requires different versions of your base 
-    programming language or different versions of various third-party packages from the versions 
-    that you are currently using.
-*   An application you developed as part of a previous research project that worked fine on your 
-    system six months ago now no longer works.
-*   Code that have written for a joint research project works on your machine but not on your 
-    collaborators' machines.
-*   An application that you are developing on your local machine doesn't provide the same results 
-    when run on your remote cluster.
+*   Conda can quickly install, run, and update packages and their dependencies.
+*   Conda can create, save, load, and switch between project specific software environments on 
+    your local computer. 
+*   Although Conda was created for Python programs, Conda can package and distribute software for 
+    any language such as R, Ruby, Lua, Scala, Java, JavaScript, C, C++, FORTRAN.
 
-An environment management system enables you to set up a new, project specific software environment 
-containing specific Python versions as well as the versions of additional packages and 
-required dependencies that are all mutually compatible.
+Conda as a *package manager* helps you find and install packages. If you need a package that 
+requires a different version of Python, you do not need to switch to a different environment 
+manager, because Conda is also an *environment manager*. With just a few commands, you can set up 
+a totally separate environment to run that different version of Python, while continuing to run 
+your usual version of Python in your normal environment. 
 
-*   Environment management systems help resolve dependency issues by allowing you to use different 
-    versions of a package for different projects.
-*   Make your projects self-contained and reproducible by capturing all package dependencies in a 
-    single requirements file.
-*   Allow you to install packages on a host on which you do not have admin privileges.
+> ## Conda vs. Miniconda vs. Anaconda
+> 
+> <p align="center">
+>   <img alt="Conda vs. Miniconda vs. Anaconda" src="../fig/miniconda_vs_anaconda.png" width="500">
+> </p>
+> Users are often confused about the differences between Conda, Miniconda, and Anaconda. Conda is 
+> a tool for managing environments and installing packages. Miniconda combines Conda with Python 
+> and a small number of core packages; Anaconda includes Miniconda as well as a large number of 
+> the most widely used Python packages. 
+{: .callout}
 
-### Package management
-
-A good package management system greatly simplifies the process of installing software by... 
-
-1.  identifying and installing compatible versions of software and all required dependencies. 
-2.  handling the process of updating software as more recent versions become available.
-
-If you use some flavor of Linux, then you are probably familiar with the package manager for your 
-Linux distribution (i.e., `apt` on Ubuntu, `yum` on CentOS); if you are a Mac OSX user then you 
-might be familiar with the [Home Brew Project](https://brew.sh/) which brings a Linux-like package 
-management system to Mac OS; if you are a Windows OS user, then you may not be terribly familiar 
-with package managers as there isn't really a standard package manager for Windows (although there 
-is the [Chocolatey Project](https://chocolatey.org/)).  
-
-Operating system package management tools are great but these tools actually solve a more general 
-problem than you often face as a (data) scientist.  As a (data) scientist you typically use one or 
-two core scripting languages (i.e.,  Python, R, SQL). Each scripting language has multiple 
-versions that can potentially be installed and each scripting language will also have a large 
-number of third-party packages that will need to be installed. The exact version of your core 
-scripting language(s) and additional, third-party packages will also probably change from project 
-to project.
-
-## Why use Conda (+pip)?
+## Why use Conda?
 
 Whilst there are many different package and environment management systems that solve either the 
 package management problem or the environment management problem, Conda solves both of these 

--- a/_episodes/02-working-with-environments.md
+++ b/_episodes/02-working-with-environments.md
@@ -57,6 +57,8 @@ $ conda create --name python3-env python pip
 ~~~
 {: .language-bash}
 
+For a list of all commands, take a look at [Conda general commands](https://docs.conda.io/projects/conda/en/latest/commands.html).
+
 > ## `pip` within Conda environments
 >
 > [Pip](https://pip.pypa.io/en/stable/), the default Python package manager, is often already 

--- a/_episodes/02-working-with-environments.md
+++ b/_episodes/02-working-with-environments.md
@@ -57,18 +57,21 @@ $ conda create --name python3-env python pip
 ~~~
 {: .language-bash}
 
-> ## Always install `pip` in your Python environments
+> ## `pip` within Conda environments
 >
 > [Pip](https://pip.pypa.io/en/stable/), the default Python package manager, is often already 
 > installed on most operating systems (where it is used to manage any packages need by the OS 
-> Python). Pip is also included in the Miniconda installer. Including `pip` as an explicit 
-> dependency in your Conda environment avoids difficult to debug issues that can arise when 
-> installing packages into environments using some other `pip` installed outside your environment. 
+> Python). Pip is also included in the Miniconda installer. 
+> Some packages may not be available via Conda. If such package is still needed in a project, 
+> it is possible to install it into a conda environment, using pip.
+> Therefore it may be helpful to include `pip` as an explicit dependency in your Conda environment, 
+> to avoids difficult to debug issues, that may arise when mixing up system wide installations with those
+> within conda environments. 
 {: .callout}
 
 It is a good idea to give your environment a meaningful name in order to help yourself remember 
 the purpose of the environment. While naming things can be difficult, `$PROJECT_NAME-env` is a 
-good convention to follow.
+good convention to follow. Sometimes also the specific version of a package why you had to create a new environment is a good name
 
 The command above will create a new Conda environment called "python3" and install the most recent 
 version of Python. If you wish, you can specify a particular version of packages for `conda` to 
@@ -181,7 +184,7 @@ name of the active environment.
 
 ## Deactivate the current environment
 
-To deactivate the currently active environment use the `deactivate` command as follows.
+To deactivate the currently active environment use the Conda `deactivate` command as follows.
 
 ~~~
 (basic-scipy-env) $ conda deactivate
@@ -197,7 +200,7 @@ $
 
 > ## Returning to the `base` environment
 >
-> To simply return to the `base` Conda environment, it's better to call `conda activate` with no 
+> To return to the `base` Conda environment, it's better to call `conda activate` with no 
 > environment specified, rather than to use `deactivate`. If you run `conda deactivate` from your 
 > `base` environment, you may lose the ability to run `conda` commands at all. **Don't worry if 
 > you encounter this undesirable state! Just start a new shell.**
@@ -327,16 +330,9 @@ $ conda install scikit-learn=0.22
 
 ## Where do Conda environments live?
 
-Environments created with `conda`, by default, live in the `envs/` folder of your `miniconda3` 
-directory the absolute path to which will look something the following.
+Environments created with `conda`, by default, live in the `envs/` folder of your `miniconda3` (or `anaconda3`) directory the absolute path to which will look something the following: `/Users/$USERNAME/miniconda3/envs` or `C:\Users\$USERNAME\Anaconda3`.
 
-~~~
-$ /Users/$USERNAME/miniconda3/envs
-~~~
-{: .language-bash} 
-
-Running `ls` on your `~/miniconda3/envs/` directory will list out the directories containing the 
-existing Conda environments.
+Running `ls` (linux) / `dir` (Windows) on your anaconda `envs/` directory will list out the directories containing the existing Conda environments.
 
 > ## Location of Conda environments on Binder
 >
@@ -371,7 +367,7 @@ $ conda activate ./env
 ~~~
 {: .language-bash}
 
-It is a good idea to *always* specify a path to a sub-directory of your project directory when 
+It is often a good idea to specify a path to a sub-directory of your project directory when 
 creating an environment. Why?
 
 1.  Makes it easy to tell if your project utilizes an isolated environment by including the 
@@ -617,5 +613,4 @@ $ conda remove --prefix /path/to/conda-env/ --all
 {: .challenge}
 
 {% include links.md %}
-
 

--- a/_episodes/03-sharing-environments.md
+++ b/_episodes/03-sharing-environments.md
@@ -67,8 +67,8 @@ This `environment.yml` file would create an environment called `machine-learning
 most current and mutually compatible versions of the listed packages (including all required 
 dependencies). The newly created environment would be installed inside the `~/miniconda3/envs/` 
 directory. Alternatively, if we intended this environment file to be used to create an environment 
-inside a sub-directory call `./env` of the project directory, then we should set then `name` key 
-to `null` as follows.
+inside a sub-directory call `./env` of the project directory, we can set the `name` key 
+to `null` as follows, since the environment will be named by path.
 
 ~~~
 name: null
@@ -157,7 +157,7 @@ your `project-dir` directory.
 > directory with the following contents.
 >
 > ~~~
-> name: xgboost-env
+> name: scikit-env
 > 
 > dependencies:
 >   - ipython=7.13
@@ -166,7 +166,6 @@ your `project-dir` directory.
 >   - pip=20.0
 >   - python=3.6
 >   - scikit-learn=0.22
->   - xgboost=1.0
 > ~~~
 > {: .language-yaml}
 >
@@ -237,7 +236,7 @@ from the environment.
 
 > ## Add Dask to the environment to scale up your analytics
 > 
-> Add to the `xgboost-env` environment file and update the environment. [Dask](https://dask.org/) 
+> Add to the `scikit-env` environment file and update the environment. [Dask](https://dask.org/) 
 > provides advanced parallelism for data science workflows enabling performance at scale for the 
 > core Python data science tools such as Numpy Pandas, and Scikit-Learn.  
 >
@@ -246,19 +245,17 @@ from the environment.
 > > The `environment.yml` file should now look as follows.
 > > 
 > > ~~~
-> > name: xgboost-env
+> > name: scikit-env
 > >
 > > dependencies:
 > >   - dask=2.16
 > >   - dask-ml=1.4
-> >   - dask-xgboost=0.1
 > >   - ipython=7.13
 > >   - matplotlib=3.1
 > >   - pandas=1.0
 > >   - pip=20.0
 > >   - python=3.6
 > >   - scikit-learn=0.22
-> >   - xgboost=1.0
 > > ~~~
 > > 
 > > The following command will rebuild the environment from scratch with the new Dask dependencies.
@@ -348,5 +345,4 @@ the same name.
 {: .challenge}
 
 {% include links.md %}
-
 

--- a/_episodes/04-using-packages-and-channels.md
+++ b/_episodes/04-using-packages-and-channels.md
@@ -16,7 +16,7 @@ keypoints:
 
 ## What are Conda packages?
 
-A [conda package][conda-pkg-docs] is a compressed tarball file (`.tar.bz2`) that contains:
+A conda package is a compressed archive file (`.tar.bz2`) that contains:
 
 * system-level libraries
 * Python or other modules
@@ -67,7 +67,7 @@ A complete listing of available PyTorch packages can be found on
 
 ## What are Conda channels?
 
-Again from the [Conda documentation][conda-channels-docs], conda packages are downloaded from 
+Again from the [Conda documentation](https://conda.io/en/latest/), conda packages are downloaded from 
 remote channels, which are URLs to directories containing conda packages. The `conda` command 
 searches a default set of channels, and packages are automatically downloaded and updated from the 
 [Anaconda Cloud channels](https://repo.anaconda.com/pkgs/). 
@@ -258,11 +258,12 @@ $ pip install $SOME_PACKAGE
 >  - scikit-learn=0.21
 >  - pip=19.1
 >  - pip:
->    - kaggle=1.5
->    - yellowbrick=0.9
+>    - kaggle==1.5
+>    - yellowbrick==0.9
 > ~~~
 >
-> Note that you should include `pip` itself as a dependency and then a subsection denoting those 
+> Note the double '==' instead of '=' for the pip installation and that you should include `pip` itself 
+> as a dependency and then a subsection denoting those 
 > packages to be installed via `pip`. Also in case you are wondering, The 
 > [Yellowbrick](https://www.scikit-yb.org/en/latest/) package is a suite of visual diagnostic 
 > tools called “Visualizers” that extend the [Scikit-Learn](https://scikit-learn.org/stable/) API 
@@ -358,5 +359,4 @@ The [conda documentation][conda-install-docs] has a nice decision tree that desc
 {: .challenge}
 
 {% include links.md %}
-
 


### PR DESCRIPTION
Hei,

here a PR with few smaller change suggestions (without issues):

- 'always' is a bit strict, replaced with a bit softer recommendation
- added windows path (not everyone is on unix system and paths do look a bit different)
- few specifications added 
- null naming optional when creating environment in user defined location (may be confusing for learners)
- removed xgboost from exercises and renamed environment (not available in default channel)
- added link for channels, did not find good link for packages so removed the link placeholder (?)
- replaced = with == for packages to be installed by pip in yml (not 100% sure if this is true for all systems (macos &ubuntu tested)

Please read carefully, that these make sense. 
Also happy to change back or in another way.

-Samantha